### PR TITLE
Add plain-auth for svn direct connection

### DIFF
--- a/classes/providers/PasswdUserProvider.class.php
+++ b/classes/providers/PasswdUserProvider.class.php
@@ -24,14 +24,22 @@ namespace svnadmin\providers
   {
     private $m_userfile = NULL;
     private $m_init_done = false;
+    private static $m_type="";
     private static $m_instance = NULL;
-
-    public static function getInstance()
+    //private static $m_type="";
+    
+    private function __construct($type){
+        $this->m_type=$type;
+    }
+    
+    public static function getInstance($type="")
     {
+      self::$m_type=$type;
       if( self::$m_instance == NULL )
       {
-        self::$m_instance = new PasswdUserProvider;
+        self::$m_instance = new PasswdUserProvider($type);
       }
+      //self::$m_instance->m_type=$type;
       return self::$m_instance;
     }
 
@@ -45,7 +53,7 @@ namespace svnadmin\providers
       if( !$this->m_init_done )
       {
         $this->m_init_done = true;
-        $this->m_userfile = new \IF_HtPasswd($appEngine->getConfig()->getValue("Users:passwd", "SVNUserFile"));
+        $this->m_userfile = new \IF_HtPasswd($appEngine->getConfig()->getValue("Users:passwd", "SVNUserFile"),$this->m_type);
         return $this->m_userfile->init();
       }
       return false;

--- a/include/config.inc.php
+++ b/include/config.inc.php
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.
  */
-error_reporting(E_ERROR);
+error_reporting(E_ALL);
 include_once("./classes/util/global.func.php");
 set_exception_handler('exception_handler');
 
@@ -97,8 +97,8 @@ include_once( "./classes/core/Exceptions.class.php" );
  * iF.SVNAdmin version.
  */
 define("MAJOR_VERSION", "1");
-define("MINOR_VERSION", "6.3");
-define("VERSION_EXTRA", "UNOFFICIAL");
+define("MINOR_VERSION", "6.2");
+define("VERSION_EXTRA", "");
 
 /**
  * Constant ACL modules.
@@ -127,8 +127,6 @@ define("ACL_ACTION_CHANGEPASS_OTHER",	"changepassother");	// ACL_MOD_USER only!
 define("ACL_ACTION_SYNCHRONIZE",		"synchronize");		// ACL_MOD_UPDATE only!
 define("ACL_ACTION_CHANGE",				"change");			// ACL_MOD_SETTINGS only (atm...)!
 define("ACL_ACTION_DUMP",				"dump");			// ACL_MOD_REPO
-define("ACL_ACTION_ASSIGN_ADMIN_ROLE", "assignadmin"); // ACL_MOD_ROLE
-define("ACL_ACTION_UNASSIGN_ADMIN_ROLE", "unassignadmin"); // ACL_MOD_ROLE
 
 /*
  * Switch current locale procecure.
@@ -176,7 +174,7 @@ if ($cfg->getValue("Engine:Providers", "UserViewProviderType") == "passwd")
 {
   include_once($ifcorelib_path."IF_HtPasswd.class.php");
   include_once("./classes/providers/PasswdUserProvider.class.php");
-  $userView = \svnadmin\providers\PasswdUserProvider::getInstance();
+  $userView = \svnadmin\providers\PasswdUserProvider::getInstance($cfg->getValue("Engine:Providers", "AuthenticationStatus"));
   $appEngine->setUserViewProvider( $userView );
 }
 elseif ($cfg->getValue("Engine:Providers", "UserViewProviderType") == "digest")
@@ -190,7 +188,7 @@ elseif ($cfg->getValue("Engine:Providers", "UserViewProviderType") == "ldap")
 {
 	$userView = null;
 	include_once("./classes/providers/ldap/LdapUserViewProvider.class.php");
-
+  
 	if ($cfg->getValueAsBoolean('Ldap', 'CacheEnabled', false)) {
 		include_once("./classes/providers/ldap/CachedLdapUserViewProvider.class.php");
 		include_once("./include/ifcorelib/IF_JsonObjectStorage.class.php");
@@ -200,7 +198,6 @@ elseif ($cfg->getValue("Engine:Providers", "UserViewProviderType") == "ldap")
 		$userView = \svnadmin\providers\ldap\LdapUserViewProvider::getInstance();
 	}
 
-	$userView->setUserViewEnabled(true);
 	$appEngine->setUserViewProvider( $userView );
 }
 
@@ -212,7 +209,7 @@ if ($cfg->getValue("Engine:Providers", "UserEditProviderType") == "passwd")
 {
   include_once($ifcorelib_path."IF_HtPasswd.class.php");
   include_once( "./classes/providers/PasswdUserProvider.class.php" );
-  $userEdit = \svnadmin\providers\PasswdUserProvider::getInstance();
+  $userEdit = \svnadmin\providers\PasswdUserProvider::getInstance($cfg->getValue("Engine:Providers", "AuthenticationStatus"));
   $appEngine->setUserEditProvider( $userEdit );
 }
 if ($cfg->getValue("Engine:Providers", "UserEditProviderType") == "digest")
@@ -237,7 +234,7 @@ elseif($cfg->getValue("Engine:Providers", "GroupViewProviderType") == "ldap" && 
 	$groupView = null;
 	include_once("./classes/providers/ldap/LdapUserViewProvider.class.php");
 	include_once("./classes/providers/AuthFileGroupAndPathsProvider.class.php");
-
+	
 	if ($cfg->getValueAsBoolean('Ldap', 'CacheEnabled', false)) {
 		include_once("./classes/providers/ldap/CachedLdapUserViewProvider.class.php");
 		include_once("./include/ifcorelib/IF_JsonObjectStorage.class.php");
@@ -246,8 +243,7 @@ elseif($cfg->getValue("Engine:Providers", "GroupViewProviderType") == "ldap" && 
 	else {
 		$groupView = \svnadmin\providers\ldap\LdapUserViewProvider::getInstance();
 	}
-
-	$groupView->setGroupViewEnabled(true);
+	
 	$appEngine->setGroupViewProvider($groupView);
 }
 
@@ -305,8 +301,8 @@ if ($cfg->getValue("Engine:Providers", "RepositoryEditProviderType") == "svnclie
 /**
  * Authentication status.
  */
-if ($cfg->getValue("Engine:Providers", "AuthenticationStatus") == "basic")
-{
+//if ($cfg->getValue("Engine:Providers", "AuthenticationStatus") == "basic")
+//{
   include( "./classes/providers/EngineBaseAuthenticator.class.php" );
   session_start();
   $o = new \svnadmin\providers\EngineBaseAuthenticator;
@@ -321,7 +317,7 @@ if ($cfg->getValue("Engine:Providers", "AuthenticationStatus") == "basic")
     $appEngine->setAclManager($o);
     $appTemplate->setAcl($appEngine);
   }
-}
+//}
 
 /**
  * An administrator role MUST be defined, if the authentication is active.

--- a/include/ifcorelib/IF_HtPasswd.class.php
+++ b/include/ifcorelib/IF_HtPasswd.class.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright (c) 2010 by Manuel Freiholz
  * http://www.insanefactory.com/
@@ -27,196 +28,172 @@
  *
  * @author Manuel Freiholz, insaneFactory.com
  */
-class IF_HtPasswd
-{
-	// Holds the user file as an array (username=>encrypted-password)
-	private $m_data = array();
+class IF_HtPasswd {
 
-	// Holds the path to the user authentication file.
-	private $m_userfile = NULL;
+    // Holds the user file as an array (username=>encrypted-password)
+    private $m_data = array();
+    // Holds the path to the user authentication file.
+    private $m_userfile = NULL;
+    // Holds the error number, if a error occured.
+    private $m_errno = 0;
+    // private static $m_seperator=',';
+    private $m_seperator = ' = ';
+    //private static $m_header='';
+    private $m_header = '[users]';
+    
+    private $m_type  = '';
 
-	// Holds the error number, if a error occured.
-	private $m_errno = 0;
+    //////////////////////////////////////////////////////////////////////////////
 
-	//////////////////////////////////////////////////////////////////////////////
-
-	/**
-	 * Creates a new instance of this class and assigns the given
-	 * file as "passwd" file to it.
-	 *
-	 * @param string $userfile
-	 */
-	public function __construct( $userfile )
-	{
-		$this->m_userfile = $userfile;
-	}
-
-	/**
-	 * Loads the file content and does some init operations.
-	 *
-	 * @return void
-	 */
-  public function init()
-  {
-  	$b = self::parseUserFile( $this->m_userfile );
-  	return $b;
-  }
-
-  public function errno()
-  {
-  	return $this->m_errno;
-  }
-
-  public function error()
-  {
-  	switch( $this->m_errno )
-  	{
-  		case 1: return "The user authentication file does not exist.";
-  		case 2: return "No READ permission on the user authentication file.";
-  		case 10: return "The user already exists.";
-  		case 11: return "The user does not exist.";
-  		default: return "No error occured.";
-  	}
-  }
-
-  /**
-   * Gets a list filled with all users in the file.
-   *
-   * @return array<string> List of users.
-   */
-  public function getUserList()
-  {
-  	$retUsers = array();
-  	foreach( $this->m_data as $username=>$pass )
-  	{
-  		array_push( $retUsers, $username );
-  	}
-  	return $retUsers;
-  }
-
-  /**
-   * Creates a new user inside the object.
-   * Call writeToFile(...) to save the user to disc.
-   *
-   * @param string $username
-   * @param string $password
-   * @param bool $crypt
-   */
-  public function createUser( $username, $password, $crypt = true )
-  {
-    if( self::userExists( $username ) )
-    {
-    	// The user already exists.
-      $this->m_errno = 10;
-      return false;
+    /**
+     * Creates a new instance of this class and assigns the given
+     * file as "passwd" file to it.
+     *
+     * @param string $userfile
+     */
+    public function __construct($userfile,$type="") {
+        $this->m_userfile = $userfile;
+        $this->type = $type;
     }
 
-  	// Should the password being crypted?
-  	if( $crypt == true )
-  	{
-  		$password = self::crypt_default( $password ); // Force MD5 as salt!
-  	}
-
-  	// Add the user to the holded data array.
-    $this->m_data[$username] = $password;
-    return true;
-  }
-
-  public function changePassword($username, $newpass, $crypt=true)
-  {
-    if (self::userExists($username))
-    {
-      if ($crypt && !empty($newpass))
-      {
-        $newpass = self::crypt_default($newpass);
-      }
-      $this->m_data[$username] = $newpass;
-      return true;
+    /**
+     * Loads the file content and does some init operations.
+     *
+     * @return void
+     */
+    public function init() {
+        $b = self::parseUserFile($this->m_userfile);
+        return $b;
     }
-    else
-      return false;
-  }
 
-  public function deleteUser( $username )
-  {
-    if( !self::userExists( $username ) )
-    {
-    	// The user does not exists.
-    	$this->m_errno = 11;
-    	return false;
+    public function errno() {
+        return $this->m_errno;
     }
-    else
-    {
-    	// Unset user.
-      unset( $this->m_data[$username] );
-      return true;
+
+    public function error() {
+        switch ($this->m_errno) {
+            case 1: return "The user authentication file does not exist.";
+            case 2: return "No READ permission on the user authentication file.";
+            case 10: return "The user already exists.";
+            case 11: return "The user does not exist.";
+            default: return "No error occured.";
+        }
     }
-  }
 
-  public function userExists( $username )
-  {
-  	if( isset( $this->m_data[$username] ) && !empty( $this->m_data[$username] ) )
-  	{
-  		return true;
-  	}
-  	else
-  	{
-  		return false;
-  	}
-  }
+    /**
+     * Gets a list filled with all users in the file.
+     *
+     * @return array<string> List of users.
+     */
+    public function getUserList() {
+        $retUsers = array();
+        foreach ($this->m_data as $username => $pass) {
+            array_push($retUsers, $username);
+        }
+        return $retUsers;
+    }
 
-  public function authenticate( $username, $password )
-  {
-  	// Find the user.
-    foreach( $this->m_data as $usr=>&$pass )
-    {
-    	// Found user.
-      if( $usr == $username )
-      {
-      	// Find out which encryption type is used.
-      	// SHA
-      	if (strpos($pass, "{SHA}") === 0)
-      	{
-      		$password_crypted = self::crypt_sha($password);
+    /**
+     * Creates a new user inside the object.
+     * Call writeToFile(...) to save the user to disc.
+     *
+     * @param string $username
+     * @param string $password
+     * @param bool $crypt
+     */
+    public function createUser($username, $password, $crypt = true) {
+        if (self::userExists($username)) {
+            // The user already exists.
+            $this->m_errno = 10;
+            return false;
+        }
+
+        // Should the password being crypted?
+        if ($crypt == true) {
+            $password = self::crypt_default($password); // Force MD5 as salt!
+        }
+
+        // Add the user to the holded data array.
+        $this->m_data[$username] = $password;
+        return true;
+    }
+
+    public function changePassword($username, $newpass, $crypt = true) {
+        if (self::userExists($username)) {
+            if ($crypt && !empty($newpass)) {
+                $newpass = self::crypt_default($newpass);
+            }
+            $this->m_data[$username] = $newpass;
+            return true;
+        } else
+            return false;
+    }
+
+    public function deleteUser($username) {
+        if (!self::userExists($username)) {
+            // The user does not exists.
+            $this->m_errno = 11;
+            return false;
+        } else {
+            // Unset user.
+            unset($this->m_data[$username]);
+            return true;
+        }
+    }
+
+    public function userExists($username) {
+        if (isset($this->m_data[$username]) && !empty($this->m_data[$username])) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public function authenticate($username, $password) {
+        // Find the user.
+        foreach ($this->m_data as $usr => &$pass) {
+            // Found user.
+            if ($usr == $username) {
+                // Find out which encryption type is used.
+                // SHA
+                if (strpos($pass, "{SHA}") === 0) {
+                    $password_crypted = self::crypt_sha($password);
 
 //      		echo "Type: SHA\n";
 //          echo "Password-In-File: ".$pass."\n";
 //      		echo "Password-Crypted: ".$password_crypted."\n";
 
-      		if ($password_crypted == $pass)
-      		  return true;
-      		else
-      		  return false;
-      	}
-      	// MD5
-      	elseif (strpos($pass, '$apr1$') === 0 && preg_match('/\$(.*)\$(.*)\$(.*)/', $pass, $matches) > 0)
-      	{
-      		// Stick togehter the salt of the password.
-      		$salt = $matches[2];
+                    if ($password_crypted == $pass)
+                        return true;
+                    else
+                        return false;
+                }
+                // MD5
+                elseif (strpos($pass, '$apr1$') === 0 && preg_match('/\$(.*)\$(.*)\$(.*)/', $pass, $matches) > 0) {
+                    // Stick togehter the salt of the password.
+                    $salt = $matches[2];
 
-      		// Crypt the user entered password.
-      		$password_crypted = self::crypt_apr1_md5($password, $salt);
+                    // Crypt the user entered password.
+                    $password_crypted = self::crypt_apr1_md5($password, $salt);
 
 //          echo "Type: MD5\n";
 //          echo "Password-In-File: ".$pass."\n";
 //          echo "Password-Salt   : ".$salt."\n";
 //          echo "Password-Crypted: ".$password_crypted."\n";
 
-      		if ($password_crypted == $pass)
-      		  return true;
-      		else
-      		  return false;
-      	}
-      	// CRYPT (only unix)
-      	else
-      	{
-      		// The different length of salts.
-      		$crypt_types = array("STD-DES" => 2, "EXT-DES" => 9, "MD5" => 12, "BLOWFISH" => 16);
+                    if ($password_crypted == $pass)
+                        return true;
+                    else
+                        return false;
+                }
+                // CRYPT (only unix)
+                else {
+                    // The different length of salts.
+                    $crypt_types = array("STD-DES" => 2, "EXT-DES" => 9, "MD5" => 12, "BLOWFISH" => 16);
 
-      		foreach ($crypt_types as $type=>$len)
-      		{
-      			$salt = substr($pass, 0, $len);
-      			$password_crypted = self::crypt_unix($password, $salt);
+                    foreach ($crypt_types as $type => $len) {
+                        $salt = substr($pass, 0, $len);
+                        $password_crypted = self::crypt_unix($password, $salt);
 
 //	          echo "Type: CRYPT (Unix only)\n";
 //	          echo "Hash-Type: ".$type."\n";
@@ -225,228 +202,224 @@ class IF_HtPasswd
 //	          echo "Password-Crypted: ".$password_crypted."\n";
 //	          echo "\n";
 
-	          if ($password_crypted == $pass)
-	            return true;
-	          else
-	            continue;
-      		}
-      		return false;
-      	}
-      }
+                        if ($password_crypted == $pass)
+                            return true;
+                        else
+                            continue;
+                    }
+                    
+                    //plain authentication
+                    if ($password == $pass) {
+                        return true;
+                    }
+                    
+                    return false;
+                }
+            }
+        }
+
+        // User not found.
+        return false;
     }
 
-    // User not found.
-    return false;
-  }
+    //////////////////////////////////////////////////////////////////////////////
 
-  //////////////////////////////////////////////////////////////////////////////
+    /**
+     * Parses the user file and saves the data in a localy holded array, which
+     * can be accessed by the public functions of this class.
+     *
+     * @param striing $userfile The file to parse.
+     * @return bool
+     */
+    private function parseUserFile($userfile) {
+        if (!file_exists($userfile)) {
+            // File does not exist.
+            $this->m_errno = 1;
+            return false;
+        }
 
-  /**
-   * Parses the user file and saves the data in a localy holded array, which
-   * can be accessed by the public functions of this class.
-   *
-   * @param striing $userfile The file to parse.
-   * @return bool
-   */
-  private function parseUserFile( $userfile )
-  {
-    if( !file_exists( $userfile ) )
-    {
-    	// File does not exist.
-    	$this->m_errno = 1;
-    	return false;
+        if (!is_readable($userfile)) {
+            // No permission to read the file.
+            $this->m_errno = 2;
+            return false;
+        }
+
+        // Open file in read-mode.
+        $fh = fopen($userfile, "r");
+        flock($fh, LOCK_SH);
+
+        // Read each line as one user entry.
+        while (!feof($fh)) {
+            $line = fgets($fh);
+            $line = trim($line);
+
+            if (empty($line) || $line==$this->m_header) {
+                continue;
+            }
+
+            // Split the line by ':'.
+            // [0] = Username
+            // [1] = Crypted password
+            $values = explode($this->m_seperator, $line);
+
+            if (count($values) == 2) {
+                $this->m_data[$values[0]] = $values[1];
+            }
+        }
+        flock($fh, LOCK_UN);
+        fclose($fh);
+        return true;
     }
 
-    if( !is_readable( $userfile  ) )
-    {
-    	// No permission to read the file.
-    	$this->m_errno = 2;
-    	return false;
+    /**
+     * Saves the local m_data, which holds the user information to the given file.
+     *
+     * @param $filename
+     * @return unknown_type
+     */
+    public function writeToFile($filename = NULL) {
+        if ($filename == NULL) {
+            $filename = $this->m_userfile;
+        }
+
+        // Open file and write the array of users to it.
+        $fh = fopen($filename, "w");
+        flock($fh, LOCK_EX);
+        if (!empty($this->m_header))
+            fwrite($fh, $this->m_header . "\n", strlen($this->m_header) + 1);
+        foreach ($this->m_data as $usr => $pwd) {
+            $line = $usr . $this->m_seperator . $pwd . "\n";
+            fwrite($fh, $line, strlen($line));
+        }
+        flock($fh, LOCK_UN);
+        fclose($fh);
+        return true;
     }
 
-    // Open file in read-mode.
-    $fh = fopen( $userfile, "r" );
-    flock( $fh, LOCK_SH );
+    //////////////////////////////////////////////////////////////////////////////
+    // Additional crypt functions.
+    //////////////////////////////////////////////////////////////////////////////
 
-    // Read each line as one user entry.
-    while( !feof( $fh ) )
-    {
-      $line = fgets( $fh );
-      $line = trim( $line );
+    /**
+     * @param string $plainpasswd
+     */
+    private function crypt_default($plainpasswd) {
+        if(empty($this->m_type)){
+            if (defined("IF_HtPasswd_DefaultCrypt")) {
+                $this->m_type = IF_HtPasswd_DefaultCrypt;
+            }
+        }
 
-      if( empty( $line ) )
-      {
-      	continue;
-      }
-
-      // Split the line by ':'.
-      // [0] = Username
-      // [1] = Crypted password
-      $values = explode( ":", $line );
-
-      if( count( $values ) == 2 )
-      {
-        $this->m_data[$values[0]] = $values[1];
-      }
-    }
-    flock( $fh, LOCK_UN );
-    fclose( $fh );
-    return true;
-  }
-
-  /**
-   * Saves the local m_data, which holds the user information to the given file.
-   *
-   * @param $filename
-   * @return unknown_type
-   */
-  public function writeToFile( $filename = NULL )
-  {
-    if( $filename == NULL )
-    {
-      $filename = $this->m_userfile;
+        switch ($this->m_type) {
+            case "CRYPT":
+            case "complex":
+                return self::crypt_unix($plainpasswd);
+            
+            case "SHA1":
+            case "advanced":
+                return self::crypt_sha($plainpasswd);
+                
+            case "MD5":
+            case "basic":
+            case "base":
+                return self::crypt_apr1_md5($plainpasswd);
+                
+            case "off":
+            case "none":
+            default:
+                //return self::crypt_apr1_md5($plainpasswd);
+                return $plainpasswd;
+        }
     }
 
-    // Open file and write the array of users to it.
-    $fh = fopen( $filename, "w" );
-    flock( $fh, LOCK_EX );
-    foreach( $this->m_data as $usr=>$pwd )
-    {
-      $line = $usr.":".$pwd."\n";
-      fwrite( $fh, $line, strlen( $line ) );
+    /**
+     * Creates a default unix crypt hash of the given password with the
+     * specified salt. If no salt is given then the function will use its own
+     * generated salt.
+     *
+     * @param string $plainpasswd
+     * @param string $salt
+     * @return string
+     */
+    private function crypt_unix($plainpasswd, $salt = "") {
+        $password_crypted = "";
+        if (empty($salt)) {
+            $password_crypted = crypt($plainpasswd);
+        } else {
+            $password_crypted = crypt($plainpasswd, $salt);
+        }
+        return $password_crypted;
     }
-    flock( $fh, LOCK_UN );
-    fclose( $fh );
-    return true;
-  }
 
-  //////////////////////////////////////////////////////////////////////////////
-  // Additional crypt functions.
-  //////////////////////////////////////////////////////////////////////////////
+    /**
+     * Creates an SHA1 generated hash of the given plain text password.
+     *
+     * @param string $plainpasswd
+     * @return string
+     */
+    private function crypt_sha($plainpasswd) {
+        $password_crypted = "{SHA}" . base64_encode(sha1($plainpasswd, true));
+        return $password_crypted;
+    }
 
-  /**
-   * @param string $plainpasswd
-   */
-  private function crypt_default($plainpasswd)
-  {
-  	$type = "";
-  	if (defined("IF_HtPasswd_DefaultCrypt"))
-  	{
-  		$type = IF_HtPasswd_DefaultCrypt;
-  	}
+    /**
+     * Creates an hash of the given plain text password with the specified
+     * salt. If no salt is given then the function will use it's own random
+     * generated salt.
+     *
+     * @param string $plainpasswd
+     * @param string $salt
+     * @return string Hash of the plain password.
+     */
+    private function crypt_apr1_md5($plainpasswd, $salt = "") {
+        // Use default salt?
+        $translate_to = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+        if (empty($salt)) {
+            $salt = substr(str_shuffle($translate_to), 0, 8);
+        }
 
-  	switch ($type)
-  	{
-  		case "CRYPT":
-  			return self::crypt_unix($plainpasswd);
+        // Password length.
+        $len = strlen($plainpasswd);
+        $text = $plainpasswd . '$apr1$' . $salt;
+        $bin = pack("H32", md5($plainpasswd . $salt . $plainpasswd));
 
-  		case "SHA1":
-  			return self::crypt_sha($plainpasswd);
+        for ($i = $len; $i > 0; $i -= 16) {
+            $text .= substr($bin, 0, min(16, $i));
+        }
 
-  		case "MD5":
-  			return self::crypt_apr1_md5($plainpasswd);
+        for ($i = $len; $i > 0; $i >>= 1) {
+            $text .= ($i & 1) ? chr(0) : $plainpasswd{0};
+        }
 
-  		default:
-  			return self::crypt_apr1_md5($plainpasswd);
-  	}
-  }
+        $bin = pack("H32", md5($text));
 
-  /**
-   * Creates a default unix crypt hash of the given password with the
-   * specified salt. If no salt is given then the function will use its own
-   * generated salt.
-   *
-   * @param string $plainpasswd
-   * @param string $salt
-   * @return string
-   */
-  private function crypt_unix($plainpasswd, $salt = "")
-  {
-  	$password_crypted = "";
-  	if (empty($salt))
-  	{
-  		$password_crypted = crypt($plainpasswd);
-  	}
-  	else
-  	{
-  		$password_crypted = crypt($plainpasswd, $salt);
-  	}
-  	return $password_crypted;
-  }
+        for ($i = 0; $i < 1000; $i++) {
+            $new = ($i & 1) ? $plainpasswd : $bin;
+            if ($i % 3)
+                $new .= $salt;
+            if ($i % 7)
+                $new .= $plainpasswd;
+            $new .= ($i & 1) ? $bin : $plainpasswd;
+            $bin = pack("H32", md5($new));
+        }
 
-  /**
-   * Creates an SHA1 generated hash of the given plain text password.
-   *
-   * @param string $plainpasswd
-   * @return string
-   */
-  private function crypt_sha($plainpasswd)
-  {
-  	$password_crypted = "{SHA}".base64_encode(sha1($plainpasswd, true));
-  	return $password_crypted;
-  }
+        $tmp = "";
+        for ($i = 0; $i < 5; $i++) {
+            $k = $i + 6;
+            $j = $i + 12;
+            if ($j == 16)
+                $j = 5;
+            $tmp = $bin[$i] . $bin[$k] . $bin[$j] . $tmp;
+        }
 
-  /**
-   * Creates an hash of the given plain text password with the specified
-   * salt. If no salt is given then the function will use it's own random
-   * generated salt.
-   *
-   * @param string $plainpasswd
-   * @param string $salt
-   * @return string Hash of the plain password.
-   */
-	private function crypt_apr1_md5($plainpasswd, $salt = "")
-	{
-		// Use default salt?
-		$translate_to = "./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-		if (empty($salt))
-		{
-			$salt = substr(str_shuffle($translate_to), 0, 8);
-		}
+        $tmp = chr(0) . chr(0) . $bin[11] . $tmp;
+        $tmp = strtr(
+                strrev(substr(base64_encode($tmp), 2)), "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/", $translate_to
+        );
 
-		// Password length.
-		$len = strlen($plainpasswd);
-		$text = $plainpasswd.'$apr1$'.$salt;
-		$bin = pack("H32", md5($plainpasswd.$salt.$plainpasswd));
+        return "$" . "apr1" . "$" . $salt . "$" . $tmp;
+    }
 
-		for($i=$len; $i>0; $i-=16)
-		{
-			$text.= substr($bin, 0, min(16, $i));
-		}
-
-		for($i=$len; $i>0; $i>>=1)
-		{
-			$text.= ($i & 1) ? chr(0) : $plainpasswd{0};
-		}
-
-		$bin = pack("H32", md5($text));
-
-		for($i = 0; $i < 1000; $i++)
-		{
-			$new = ($i & 1) ? $plainpasswd : $bin;
-			if ($i % 3) $new .= $salt;
-			if ($i % 7) $new .= $plainpasswd;
-			$new .= ($i & 1) ? $bin : $plainpasswd;
-			$bin = pack("H32", md5($new));
-		}
-
-		$tmp = "";
-		for ($i = 0; $i < 5; $i++)
-		{
-			$k = $i + 6;
-			$j = $i + 12;
-			if ($j == 16) $j = 5;
-			$tmp = $bin[$i].$bin[$k].$bin[$j].$tmp;
-		}
-
-		$tmp = chr(0).chr(0).$bin[11].$tmp;
-		$tmp = strtr(
-			  strrev(substr(base64_encode($tmp), 2)),
-			  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/",
-			  $translate_to
-		  );
-
-		return "$"."apr1"."$".$salt."$".$tmp;
-	}
 }
+
 ?>

--- a/pages/settings/backend.html.php
+++ b/pages/settings/backend.html.php
@@ -99,6 +99,16 @@ $(document).ready(function(){
   </thead>
   <tbody>
     <tr>
+        <td>Passwd Encryption type:</td>
+        <td>
+        <select name="PasswdEncryptionType" id="PasswdEncryptionType">
+          <?php foreach(GetArrayValue("passwdEncryptionType") as $t): ?>
+          <option><?php print($t); ?></option>
+          <?php endforeach; ?>
+        </select>
+      </td>
+    </tr>
+    <tr>
       <td>User view provider type:</td>
       <td>
         <select name="UserViewProviderType" id="UserViewProviderType">

--- a/settings.php
+++ b/settings.php
@@ -52,7 +52,7 @@ $appTR->loadModule("settings");
 ////////////////////////////////////////////////////////////////////////////////
 // Fetch request parameters.
 ////////////////////////////////////////////////////////////////////////////////
-
+$pPasswdEncryptionType = get_request_var("PasswdEncryptionType");
 $pUserViewProviderType = get_request_var("UserViewProviderType");
 $pUserEditProviderType = get_request_var("UserEditProviderType");
 $pGroupViewProviderType = get_request_var("GroupViewProviderType");
@@ -98,6 +98,7 @@ if (check_request_var("firststart"))
 
 if (check_request_var("save"))
 {
+        $cfgEngine->setValue("Engine:Providers", "AuthenticationStatus", $pPasswdEncryptionType);
 	$cfgEngine->setValue("Engine:Providers", "UserViewProviderType", $pUserViewProviderType);
 	$cfgEngine->setValue("Engine:Providers", "UserEditProviderType", $pUserEditProviderType);
 	$cfgEngine->setValue("Engine:Providers", "GroupViewProviderType", $pGroupViewProviderType);
@@ -469,6 +470,11 @@ $svnAuthFile = $cfgEngine->getValue("Subversion","SVNAuthFile");
 $svnAuthFileEx = $cfgTpl->getValue("Subversion","SVNAuthFile");
 SetValue("SVNAuthFile", $svnAuthFile);
 SetValue("SVNAuthFileEx", $svnAuthFileEx);
+
+//PasswdEncryptionType
+$passwdEncryptionType = array("off", "basic", "advanced", "complex");
+array_unshift($passwdEncryptionType, $cfgEngine->getValue("Engine:Providers","AuthenticationStatus"));
+SetValue("passwdEncryptionType", $passwdEncryptionType);
 
 // UserViewProviderType
 $userViewProviderTypes = array(/*"off",*/ "passwd", "digest", "ldap");


### PR DESCRIPTION
add plain authenticate for compatibility of svn direct connect:  svn uses a plain text passwd file, but if.svnadmin uses an encrypted passwd file , so this patch is to fix this problem. To use this patch, you should use a unique configure file for your svnserve, you can use --config-file option to direct to a unique configure file and share passwd and authz files with if.svnadmin.